### PR TITLE
Update pubspec.yaml

### DIFF
--- a/charts_flutter/pubspec.yaml
+++ b/charts_flutter/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
 
 
 dev_dependencies:
-  mockito: 3.0.0-alpha
+  mockito:
   flutter_test:
     sdk: flutter
   test: ^0.12.0


### PR DESCRIPTION
Remove package constraints on mockito as it's causing compatibility issues with Flutter's constraints:

```
Incompatible version constraints on mockito:
- charts_flutter depends on version 3.0.0-alpha
- flutter_test 0.0.0 depends on version 2.2.3
pub get failed (1)
```

Fixes https://github.com/google/charts/issues/4