### PR TITLE
Override RangeAnnotation hashcode

### DIFF
--- a/charts_flutter/lib/src/behaviors/range_annotation.dart
+++ b/charts_flutter/lib/src/behaviors/range_annotation.dart
@@ -56,5 +56,8 @@ class RangeAnnotation extends ChartBehavior<common.RangeAnnotation> {
   String get role => 'RangeAnnotation';
 
   @override
+  int get hashCode => this.runtimeType.hashCode;
+
+  @override
   bool operator ==(Object o) => o is RangeAnnotation;
 }


### PR DESCRIPTION
Currently overrides `==` without overriding `hashCode`