### PR TITLE
Fix label position on arc when startAngle is specified

### DIFF
--- a/charts_common/lib/src/chart/pie/arc_label_decorator.dart
+++ b/charts_common/lib/src/chart/pie/arc_label_decorator.dart
@@ -270,8 +270,8 @@ class ArcLabelDecorator<D> extends ArcRendererDecorator<D> {
         arcElements.center.x + labelRadius * cos(centerAngle),
         arcElements.center.y + labelRadius * sin(centerAngle));
 
-    // Factor in the [ArcRenderer] start angle (defaults to -PI/2).
-    final labelLeftOfChart = centerAngle > pi + arcElements.startAngle;
+    final centerAbs = centerAngle.abs() % (2 * pi);
+    final labelLeftOfChart = centerAbs > pi / 2 && centerAbs < pi * 3 / 2;
 
     // Shift the label horizontally away from the center of the chart.
     var labelX = labelLeftOfChart

--- a/charts_common/pubspec.yaml
+++ b/charts_common/pubspec.yaml
@@ -12,7 +12,8 @@ dependencies:
   intl: ^0.15.2
   logging: any
   meta: ^1.1.1
+  vector_math: any
 
 dev_dependencies:
-  mockito: 3.0.0-alpha
-  test: ^0.12.0
+  mockito: 3.0.0
+  test: ^1.3.0


### PR DESCRIPTION
Fixes problem with labels being in the incorrect position when a startAngle is specified in the ArcRendererConfig, see Issue https://github.com/google/charts/issues/119 for example code