### PR TITLE
Arch length for arch renderer

### DIFF
--- a/charts_common/lib/src/chart/pie/arc_renderer.dart
+++ b/charts_common/lib/src/chart/pie/arc_renderer.dart
@@ -95,6 +95,7 @@ class ArcRenderer<D> extends BaseSeriesRenderer<D> {
       // On the canvas, arc measurements are defined as angles from the positive
       // x axis. Start our first slice at the positive y axis instead.
       var startAngle = config.startAngle;
+      var arcLength = config.arcLength;
 
       var totalAngle = 0.0;
 
@@ -106,12 +107,12 @@ class ArcRenderer<D> extends BaseSeriesRenderer<D> {
         //
         // Use a tiny epsilon difference to ensure that the canvas renders a
         // "full" circle, in the correct direction.
-        var angle = 2 * pi * .999999;
-        var endAngle = startAngle + angle;
+        var angle = arcLength == 2 * pi ? arcLength * .999999 : arcLength;
+        var arcEndAngle = startAngle + angle;
 
         var details = new ArcRendererElement<D>();
         details.startAngle = startAngle;
-        details.endAngle = endAngle;
+        details.endAngle = arcEndAngle;
         details.index = 0;
         details.key = 0;
         details.series = series;
@@ -128,12 +129,12 @@ class ArcRenderer<D> extends BaseSeriesRenderer<D> {
           }
 
           final percentOfSeries = (measure / seriesMeasureTotal);
-          var angle = percentOfSeries * 2 * pi;
-          var endAngle = startAngle + angle;
+          var angle = arcLength * percentOfSeries;
+          var arcEndAngle = startAngle + angle;
 
           var details = new ArcRendererElement<D>();
           details.startAngle = startAngle;
-          details.endAngle = endAngle;
+          details.endAngle = arcEndAngle;
           details.index = arcIndex;
           details.key = arcIndex;
           details.domain = domain;
@@ -142,7 +143,7 @@ class ArcRenderer<D> extends BaseSeriesRenderer<D> {
           elements.add(details);
 
           // Update the starting angle for the next datum in the series.
-          startAngle = endAngle;
+          startAngle = arcEndAngle;
 
           totalAngle = totalAngle + angle;
         }

--- a/charts_common/lib/src/chart/pie/arc_renderer_config.dart
+++ b/charts_common/lib/src/chart/pie/arc_renderer_config.dart
@@ -57,6 +57,11 @@ class ArcRendererConfig<D> extends LayoutViewConfig
   /// default startAngle is -π/2.
   final double startAngle;
 
+  /// Total arc length, in radians.
+  ///
+  /// The default arcLength is 2π.
+  final double arcLength;
+
   /// Stroke width of the border of the arcs.
   final double strokeWidthPx;
 
@@ -75,6 +80,7 @@ class ArcRendererConfig<D> extends LayoutViewConfig
       this.layoutPaintOrder = LayoutViewPaintOrder.arc,
       this.minHoleWidthForCenterContent = 30,
       this.startAngle = -pi / 2,
+      this.arcLength = 2 * pi,
       this.strokeWidthPx = 2.0,
       this.symbolRenderer})
       : this.stroke = StyleFactory.style.white,

--- a/charts_common/pubspec.yaml
+++ b/charts_common/pubspec.yaml
@@ -12,7 +12,8 @@ dependencies:
   intl: ^0.15.2
   logging: any
   meta: ^1.1.1
+  vector_math: any
 
 dev_dependencies:
-  mockito: 3.0.0-alpha
-  test: ^0.12.0
+  mockito: 3.0.0
+  test: ^1.3.0


### PR DESCRIPTION
Adding an arc length parameter for allow creation of partial pies, partial donuts and gauge graphs. See issue https://github.com/google/charts/issues/121