### PR TITLE
Fix horizontal follow line to match vertical follow line

### DIFF
--- a/charts_common/lib/src/chart/common/behavior/line_point_highlighter.dart
+++ b/charts_common/lib/src/chart/common/behavior/line_point_highlighter.dart
@@ -454,7 +454,7 @@ class _LinePointLayoutView<D> extends LayoutView {
             ],
             stroke: StyleFactory.style.linePointHighlighterColor,
             strokeWidthPx: 1.0,
-            dashPattern: [1, 3]);
+            dashPattern: dashPattern);
 
         if (showHorizontalFollowLine ==
             LinePointHighlighterFollowLineType.nearest) {


### PR DESCRIPTION
The horizontal follow line for `LinePointHighlighter` behavior was always being drawn as a dashed line and could not be changed. This change makes it match the vertical follow line pattern which can be changed with the `dashPattern` parameter.