### PR TITLE
[PointRenderer.update] fix performance issue

### DIFF
--- a/charts_common/lib/src/chart/scatter_plot/point_renderer.dart
+++ b/charts_common/lib/src/chart/scatter_plot/point_renderer.dart
@@ -253,6 +253,13 @@ class PointRenderer<D> extends BaseCartesianRenderer<D> {
             measureOffsetValue,
             measureAxis);
 
+        // Don't process points which are located outside the draw bounds.
+        // Otherwise we have performance issue from >300/400 items in one series.
+        // This 'update' method is called many times during swipe actions
+        // (via onDragUpdate) which makes the performance even harder. As a result
+        // it takes too much time for (all points) x (all series) x (all onDragUpdate calls)
+        if (!componentBounds.containsPoint(point)) continue;
+
         final pointKey = keyFn(index);
 
         // If we already have an AnimatingPoint for that index, use it.

--- a/charts_flutter/example/lib/scatter_plot_chart/animation_zoom.dart
+++ b/charts_flutter/example/lib/scatter_plot_chart/animation_zoom.dart
@@ -52,8 +52,9 @@ class ScatterPlotAnimationZoomChart extends StatelessWidget {
 
     final makeRadius = (int value) => (random.nextInt(value) + 2).toDouble();
 
-    for (var i = 0; i < 100; i++) {
-      data.add(new LinearSales(i, random.nextInt(100), makeRadius(4)));
+    // Test pan performance
+    for (var i = 0; i < 1000; i++) {
+      data.add(new LinearSales(i, random.nextInt(1000), makeRadius(4)));
     }
 
     final maxMeasure = 100;
@@ -84,11 +85,16 @@ class ScatterPlotAnimationZoomChart extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return new charts.ScatterPlotChart(seriesList,
-        animate: animate,
-        behaviors: [
-          new charts.PanAndZoomBehavior(),
-        ]);
+    return new charts.ScatterPlotChart(
+      seriesList,
+      animate: animate,
+      behaviors: [
+        new charts.PanAndZoomBehavior(),
+      ],
+      domainAxis: charts.NumericAxisSpec(
+        viewport: charts.NumericExtents(10, 70),
+      ),
+    );
   }
 
   /// Create one series with sample hard coded data.


### PR DESCRIPTION
Don't process points which are located outside the draw bounds. Otherwise we have performance issue from >300/400 items in one series. This 'update' method is called many times during swipe actions (via onDragUpdate) which makes the performance even harder. 

As a result it takes too much time for (all points) x (all series) x (all onDragUpdate calls).
Also I have updated ScatterPlotAnimationZoomChart example to produce the issue and test the fix.