### PR TITLE
Showing dash pattern in legend.

### DIFF
--- a/charts_common/lib/src/chart/common/behavior/legend/legend_entry.dart
+++ b/charts_common/lib/src/chart/common/behavior/legend/legend_entry.dart
@@ -30,6 +30,7 @@ class LegendEntry<D> {
   final int datumIndex;
   final D domain;
   final Color color;
+  final List<int> dashPattern;
   final TextStyleSpec textStyle;
   double value;
   String formattedValue;
@@ -68,6 +69,7 @@ class LegendEntry<D> {
       this.domain,
       this.value,
       this.color,
+      this.dashPattern,
       this.textStyle,
       this.isSelected = false,
       this.rowNumber,

--- a/charts_common/lib/src/chart/common/behavior/legend/per_datum_legend_entry_generator.dart
+++ b/charts_common/lib/src/chart/common/behavior/legend/per_datum_legend_entry_generator.dart
@@ -42,6 +42,7 @@ class PerDatumLegendEntryGenerator<D> implements LegendEntryGenerator<D> {
       legendEntries.add(new LegendEntry<D>(
           series, series.domainFn(i).toString(),
           color: series.colorFn(i),
+          dashPattern: series.dashPatternFn(i),
           datum: series.data[i],
           datumIndex: i,
           textStyle: entryTextStyle));

--- a/charts_common/lib/src/chart/common/behavior/legend/per_datum_legend_entry_generator.dart
+++ b/charts_common/lib/src/chart/common/behavior/legend/per_datum_legend_entry_generator.dart
@@ -42,7 +42,7 @@ class PerDatumLegendEntryGenerator<D> implements LegendEntryGenerator<D> {
       legendEntries.add(new LegendEntry<D>(
           series, series.domainFn(i).toString(),
           color: series.colorFn(i),
-          dashPattern: series.dashPatternFn(i),
+          dashPattern: series.dashPatternFn != null ? series.dashPatternFn(i) : null,
           datum: series.data[i],
           datumIndex: i,
           textStyle: entryTextStyle));

--- a/charts_common/lib/src/chart/common/behavior/legend/per_series_legend_entry_generator.dart
+++ b/charts_common/lib/src/chart/common/behavior/legend/per_series_legend_entry_generator.dart
@@ -39,7 +39,7 @@ class PerSeriesLegendEntryGenerator<D> implements LegendEntryGenerator<D> {
   List<LegendEntry<D>> getLegendEntries(List<MutableSeries<D>> seriesList) {
     final legendEntries = seriesList
         .map((series) => new LegendEntry<D>(series, series.displayName,
-            color: series.colorFn(0), textStyle: entryTextStyle))
+            color: series.colorFn(0), dashPattern: series.dashPatternFn(0), textStyle: entryTextStyle))
         .toList();
 
     // Update with measures only if showing measure on no selection.

--- a/charts_common/lib/src/chart/common/behavior/legend/per_series_legend_entry_generator.dart
+++ b/charts_common/lib/src/chart/common/behavior/legend/per_series_legend_entry_generator.dart
@@ -39,7 +39,10 @@ class PerSeriesLegendEntryGenerator<D> implements LegendEntryGenerator<D> {
   List<LegendEntry<D>> getLegendEntries(List<MutableSeries<D>> seriesList) {
     final legendEntries = seriesList
         .map((series) => new LegendEntry<D>(series, series.displayName,
-            color: series.colorFn(0), dashPattern: series.dashPatternFn(0), textStyle: entryTextStyle))
+            color: series.colorFn(0),
+            dashPattern:
+              series.dashPatternFn != null ? series.dashPatternFn(0) : null,
+            textStyle: entryTextStyle))
         .toList();
 
     // Update with measures only if showing measure on no selection.

--- a/charts_flutter/lib/src/behaviors/legend/legend_entry_layout.dart
+++ b/charts_flutter/lib/src/behaviors/legend/legend_entry_layout.dart
@@ -56,6 +56,7 @@ class SimpleLegendEntryLayout implements LegendEntryLayout {
           context,
           size: materialSymbolSize,
           color: color,
+          dashPattern: legendEntry.dashPattern,
           enabled: !isHidden,
         ),
         onTapUp: makeTapUpCallback(context, legendEntry, legend));

--- a/charts_flutter/lib/src/symbol_renderer.dart
+++ b/charts_flutter/lib/src/symbol_renderer.dart
@@ -31,7 +31,7 @@ class SymbolRendererCanvas implements SymbolRendererBuilder {
 
   @override
   Widget build(BuildContext context,
-      {Color color, Size size, bool enabled = true}) {
+      {Color color, List<int> dashPattern, Size size, bool enabled = true}) {
     if (!enabled) {
       color = color.withOpacity(0.26);
     }
@@ -40,7 +40,7 @@ class SymbolRendererCanvas implements SymbolRendererBuilder {
         size: size,
         child: new CustomPaint(
             painter:
-                new _SymbolCustomPaint(context, commonSymbolRenderer, color)));
+                new _SymbolCustomPaint(context, commonSymbolRenderer, color, dashPattern)));
   }
 }
 
@@ -54,7 +54,7 @@ abstract class CustomSymbolRenderer extends common.SymbolRenderer
   /// Must override this method to build the custom Widget with the given color
   /// as
   @override
-  Widget build(BuildContext context, {Color color, Size size, bool enabled});
+  Widget build(BuildContext context, {Color color, List<int> dashPattern, Size size, bool enabled});
 
   @override
   void paint(common.ChartCanvas canvas, Rectangle<num> bounds,
@@ -74,7 +74,7 @@ abstract class CustomSymbolRenderer extends common.SymbolRenderer
 /// Common interface for [CustomSymbolRenderer] & [SymbolRendererCanvas] for
 /// convenience for [LegendEntryLayout].
 abstract class SymbolRendererBuilder {
-  Widget build(BuildContext context, {Color color, Size size, bool enabled});
+  Widget build(BuildContext context, {Color color, List<int> dashPattern, Size size, bool enabled});
 }
 
 /// The Widget which fulfills the guts of [SymbolRendererCanvas] actually
@@ -83,8 +83,9 @@ class _SymbolCustomPaint extends CustomPainter {
   final BuildContext context;
   final common.SymbolRenderer symbolRenderer;
   final Color color;
+  final List<int> dashPattern;
 
-  _SymbolCustomPaint(this.context, this.symbolRenderer, this.color);
+  _SymbolCustomPaint(this.context, this.symbolRenderer, this.color, this.dashPattern);
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -94,7 +95,7 @@ class _SymbolCustomPaint extends CustomPainter {
         r: color.red, g: color.green, b: color.blue, a: color.alpha);
     symbolRenderer.paint(
         new ChartCanvas(canvas, GraphicsFactory(context)), bounds,
-        fillColor: commonColor, strokeColor: commonColor);
+        fillColor: commonColor, strokeColor: commonColor, dashPattern: dashPattern);
   }
 
   @override


### PR DESCRIPTION
Legend used to indicate only color and not the dash pattern. Now the legend shows the dash pattern in addition to the color of the line. This fixes https://github.com/google/charts/issues/280