### PR TITLE
500 ms was too low for tabs with loaded content. Used to make chart blank with fast switches. 

### DIFF
--- a/charts_flutter/lib/src/chart_container.dart
+++ b/charts_flutter/lib/src/chart_container.dart
@@ -95,7 +95,7 @@ class ChartContainerRenderObject<D> extends RenderCustomPaint
   DateTime _lastConfigurationChangeTime;
 
   /// The minimum time required before the next configuration change.
-  static const configurationChangeThresholdMs = 500;
+  static const configurationChangeThresholdMs = 100;
 
   void reconfigure(ChartContainer config, BuildContext context) {
     _chartState = config.chartState;


### PR DESCRIPTION
The library is trying to protect too frequent redraws. However, 500ms was too high of a threshold for our specific situation in which we have the chart inside a tab. I have reported this as an issue before: https://github.com/google/charts/issues/276

Reducing the duration from 500ms to 100ms fixed our issue. 