### PR TITLE
fixbugs:[#292](https://github.com/google/charts/issues/292)SeriesLegend works bad when I set position bottom and  desire…

### DIFF
--- a/charts_flutter/lib/src/behaviors/legend/legend_layout.dart
+++ b/charts_flutter/lib/src/behaviors/legend/legend_layout.dart
@@ -132,7 +132,7 @@ class TabularLegendLayout implements LegendLayout {
   }
 
   Table _buildTableFromRows(List<TableRow> rows) {
-    final padWidget = new Row();
+    final padWidget = Padding(padding: cellPadding);
 
     // Pad rows to the max column count, because each TableRow in a table is
     // required to have the same number of children.
@@ -144,7 +144,8 @@ class TabularLegendLayout implements LegendLayout {
       final rowChildren = rows[i].children;
       final padCount = columnCount - rowChildren.length;
       if (padCount > 0) {
-        rowChildren.addAll(new Iterable.generate(padCount, (_) => padWidget));
+        rowChildren
+            .addAll(new Iterable<Padding>.generate(padCount, (_) => padWidget));
       }
     }
 


### PR DESCRIPTION
The Padding rows should using a Padding widget and not a Row widget.
Specifying type Iterable<Padding> in the generator.