### PR TITLE
fixbugs: #292 SeriesLegend works crashed when I set position bottom and desiredMaxColumns

### DIFF
--- a/charts_flutter/lib/src/behaviors/legend/legend_layout.dart
+++ b/charts_flutter/lib/src/behaviors/legend/legend_layout.dart
@@ -132,7 +132,7 @@ class TabularLegendLayout implements LegendLayout {
   }
 
   Table _buildTableFromRows(List<TableRow> rows) {
-    final padWidget = new Row();
+    final padWidget = Padding(padding: cellPadding);
 
     // Pad rows to the max column count, because each TableRow in a table is
     // required to have the same number of children.
@@ -144,7 +144,8 @@ class TabularLegendLayout implements LegendLayout {
       final rowChildren = rows[i].children;
       final padCount = columnCount - rowChildren.length;
       if (padCount > 0) {
-        rowChildren.addAll(new Iterable.generate(padCount, (_) => padWidget));
+        rowChildren
+            .addAll(new Iterable<Padding>.generate(padCount, (_) => padWidget));
       }
     }
 

--- a/charts_flutter/lib/src/behaviors/legend/legend_layout.dart
+++ b/charts_flutter/lib/src/behaviors/legend/legend_layout.dart
@@ -132,7 +132,7 @@ class TabularLegendLayout implements LegendLayout {
   }
 
   Table _buildTableFromRows(List<TableRow> rows) {
-    final padWidget = Padding(padding: cellPadding);
+    final padWidget = Padding(padding: cellPadding ?? EdgeInsets.all(4));
 
     // Pad rows to the max column count, because each TableRow in a table is
     // required to have the same number of children.


### PR DESCRIPTION
Fixbugs: #292  SeriesLegend works crashed when I set position bottom and desiredMaxColumns.The Padding rows should using a Padding widget and not a Row widget.Specifying type Iterable in the generator.