### PR TITLE
Fix charts_flutter TimeSeriesChart in order to use another DateTimeFactory

### DIFF
--- a/charts_flutter/lib/src/time_series_chart.dart
+++ b/charts_flutter/lib/src/time_series_chart.dart
@@ -22,7 +22,8 @@ import 'package:charts_common/common.dart' as common
         NumericAxisSpec,
         Series,
         SeriesRendererConfig,
-        TimeSeriesChart;
+        TimeSeriesChart,
+        LocalDateTimeFactory;
 import 'behaviors/chart_behavior.dart' show ChartBehavior;
 import 'behaviors/line_point_highlighter.dart' show LinePointHighlighter;
 import 'cartesian_chart.dart' show CartesianChart;
@@ -82,7 +83,8 @@ class TimeSeriesChart extends CartesianChart<DateTime> {
         layoutConfig: layoutConfig?.commonLayoutConfig,
         primaryMeasureAxis: primaryMeasureAxis?.createAxis(),
         secondaryMeasureAxis: secondaryMeasureAxis?.createAxis(),
-        disjointMeasureAxes: createDisjointMeasureAxes());
+        disjointMeasureAxes: createDisjointMeasureAxes(),
+        dateTimeFactory: dateTimeFactory ?? const common.LocalDateTimeFactory());
   }
 
   @override


### PR DESCRIPTION
charts_flutter package enables great customisation. But I noticed the dateTimeFactory field of the TimeSeriesChart is never used. (Maybe a little oversight)

This tiny fix uses the dateTimeFactory field when creating the common.TimeSeriesChart.
I needed this fix to use the common.UTCDateTimeFactory (it fixes an offset issue on the x axis ticks)

Thanks your review and your feedback :)