### PR TITLE
Revert "Bump nokogiri from 1.10.4 to 1.10.8 in /docs"

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -205,7 +205,7 @@ GEM
       jekyll-seo-tag (~> 2.1)
     minitest (5.11.3)
     multipart-post (2.1.1)
-    nokogiri (1.10.8)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)


### PR DESCRIPTION
Reverts google/charts#399

PR needs to be opened to sync