### PR TITLE
Make use of font weight settings

### DIFF
--- a/charts_common/lib/common.dart
+++ b/charts_common/lib/common.dart
@@ -236,6 +236,7 @@ export 'src/chart/treemap/treemap_label_decorator.dart'
 export 'src/chart/treemap/treemap_renderer_config.dart'
     show TreeMapRendererConfig, TreeMapTileType;
 export 'src/common/color.dart' show Color;
+export 'src/common/font_weight.dart' show FontWeight;
 export 'src/common/date_time_factory.dart'
     show DateTimeFactory, LocalDateTimeFactory, UTCDateTimeFactory;
 export 'src/common/gesture_listener.dart' show GestureListener;

--- a/charts_common/lib/src/chart/cartesian/axis/spec/axis_spec.dart
+++ b/charts_common/lib/src/chart/cartesian/axis/spec/axis_spec.dart
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:charts_common/common.dart';
 import 'package:meta/meta.dart' show immutable;
 
 import '../../../../common/color.dart' show Color;
@@ -136,7 +137,7 @@ class TextStyleSpec {
   final int fontSize;
   final double lineHeight;
   final Color color;
-  final String fontWeight;
+  final FontWeight fontWeight;
 
   const TextStyleSpec(
       {this.fontFamily,

--- a/charts_common/lib/src/chart/pie/arc_label_decorator.dart
+++ b/charts_common/lib/src/chart/pie/arc_label_decorator.dart
@@ -18,6 +18,7 @@ import 'dart:math' show cos, min, sin, pi, Point, Rectangle;
 import 'package:meta/meta.dart' show immutable, required;
 
 import '../../common/color.dart' show Color;
+import '../../common/font_weight.dart' show FontWeight;
 import '../../common/graphics_factory.dart' show GraphicsFactory;
 import '../../common/style/style_factory.dart' show StyleFactory;
 import '../../common/text_element.dart'
@@ -222,6 +223,7 @@ class ArcLabelDecorator<D> extends ArcRendererDecorator<D> {
       ..color = labelSpec?.color ?? Color.black
       ..fontFamily = labelSpec?.fontFamily
       ..fontSize = labelSpec?.fontSize ?? 12
+      ..fontWeight = labelSpec?.fontWeight ?? FontWeight.normal
       ..lineHeight = labelSpec?.lineHeight;
   }
 

--- a/charts_common/lib/src/common/font_weight.dart
+++ b/charts_common/lib/src/common/font_weight.dart
@@ -1,0 +1,38 @@
+// Copyright 2018 the Charts project authors. Please see the AUTHORS file
+// for details.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:meta/meta.dart' show immutable;
+
+@immutable
+class FontWeight {
+  const FontWeight._(this.index);
+
+  /// The encoded integer value of this font weight.
+  final int index;
+
+  /// corresponds to position of `Text.FontWeight.normal` in flutter
+  static const normal = FontWeight._(4);
+
+  /// corresponds to position of `Text.FontWeight.bold` in flutter
+  static const bold = FontWeight._(6);
+
+  @override
+  bool operator ==(Object other) => other is FontWeight && index == other.index;
+
+  @override
+  int get hashCode => index;
+
+  int asFlutterFontWeightIndex() => this.index;
+}

--- a/charts_common/lib/src/common/text_style.dart
+++ b/charts_common/lib/src/common/text_style.dart
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 import 'paint_style.dart' show PaintStyle;
+import 'font_weight.dart' show FontWeight;
 
 /// Paint properties of a text.
 abstract class TextStyle extends PaintStyle {
@@ -25,4 +26,7 @@ abstract class TextStyle extends PaintStyle {
 
   double get lineHeight;
   set lineHeight(double value);
+
+  FontWeight get fontWeight;
+  set fontWeight(FontWeight value);
 }

--- a/charts_flutter/example/lib/pie_chart/auto_label.dart
+++ b/charts_flutter/example/lib/pie_chart/auto_label.dart
@@ -19,6 +19,8 @@
 import 'dart:math';
 // EXCLUDE_FROM_GALLERY_DOCS_END
 import 'package:charts_flutter/flutter.dart' as charts;
+import 'package:charts_common/common.dart' as charts_common;
+
 import 'package:flutter/material.dart';
 
 class DonutAutoLabelChart extends StatelessWidget {
@@ -64,16 +66,13 @@ class DonutAutoLabelChart extends StatelessWidget {
         insideLabelStyleAccessorFn: (LinearSales sales, _) {
           return new charts.TextStyleSpec(
             color: charts.MaterialPalette.black,
-            fontWeight: charts.MaterialFontWeight.normal,
+            fontWeight: charts.MaterialFontWeight.w900,
           );
         },
         outsideLabelStyleAccessorFn: (LinearSales sales, _) {
-          final color = (sales.year == 2014)
-              ? charts.MaterialPalette.red.shadeDefault
-              : charts.MaterialPalette.yellow.shadeDefault.darker;
           return new charts.TextStyleSpec(
-            color: color,
-            fontWeight: charts.MaterialFontWeight.normal,
+            color: charts.MaterialPalette.yellow.shadeDefault.darker,
+            fontWeight: charts_common.FontWeight.bold,
           );
         },
         // Set a label accessor to control the text of the arc label.

--- a/charts_flutter/example/lib/pie_chart/auto_label.dart
+++ b/charts_flutter/example/lib/pie_chart/auto_label.dart
@@ -122,21 +122,15 @@ class DonutAutoLabelChart extends StatelessWidget {
         measureFn: (LinearSales sales, _) => sales.sales,
         data: data,
         insideLabelStyleAccessorFn: (LinearSales sales, _) {
-          final color = (sales.year == 2014)
-              ? charts.MaterialPalette.red.shadeDefault
-              : charts.MaterialPalette.yellow.shadeDefault.darker;
           return new charts.TextStyleSpec(
-            color: color,
-            fontWeight: charts.MaterialFontWeight.bold,
+            color: charts.MaterialPalette.black,
+            fontWeight: charts.MaterialFontWeight.w700,
           );
         },
         outsideLabelStyleAccessorFn: (LinearSales sales, _) {
-          final color = (sales.year == 2014)
-              ? charts.MaterialPalette.red.shadeDefault
-              : charts.MaterialPalette.yellow.shadeDefault.darker;
           return new charts.TextStyleSpec(
-            color: color,
-            fontWeight: charts.MaterialFontWeight.bold,
+            color: charts.MaterialPalette.yellow.shadeDefault.darker,
+            fontWeight: charts_common.FontWeight.normal,
           );
         },
         // Set a label accessor to control the text of the arc label.

--- a/charts_flutter/example/lib/pie_chart/auto_label.dart
+++ b/charts_flutter/example/lib/pie_chart/auto_label.dart
@@ -61,6 +61,21 @@ class DonutAutoLabelChart extends StatelessWidget {
         domainFn: (LinearSales sales, _) => sales.year,
         measureFn: (LinearSales sales, _) => sales.sales,
         data: data,
+        insideLabelStyleAccessorFn: (LinearSales sales, _) {
+          return new charts.TextStyleSpec(
+            color: charts.MaterialPalette.black,
+            fontWeight: charts.MaterialFontWeight.normal,
+          );
+        },
+        outsideLabelStyleAccessorFn: (LinearSales sales, _) {
+          final color = (sales.year == 2014)
+              ? charts.MaterialPalette.red.shadeDefault
+              : charts.MaterialPalette.yellow.shadeDefault.darker;
+          return new charts.TextStyleSpec(
+            color: color,
+            fontWeight: charts.MaterialFontWeight.normal,
+          );
+        },
         // Set a label accessor to control the text of the arc label.
         labelAccessorFn: (LinearSales row, _) => '${row.year}: ${row.sales}',
       )
@@ -107,6 +122,24 @@ class DonutAutoLabelChart extends StatelessWidget {
         domainFn: (LinearSales sales, _) => sales.year,
         measureFn: (LinearSales sales, _) => sales.sales,
         data: data,
+        insideLabelStyleAccessorFn: (LinearSales sales, _) {
+          final color = (sales.year == 2014)
+              ? charts.MaterialPalette.red.shadeDefault
+              : charts.MaterialPalette.yellow.shadeDefault.darker;
+          return new charts.TextStyleSpec(
+            color: color,
+            fontWeight: charts.MaterialFontWeight.bold,
+          );
+        },
+        outsideLabelStyleAccessorFn: (LinearSales sales, _) {
+          final color = (sales.year == 2014)
+              ? charts.MaterialPalette.red.shadeDefault
+              : charts.MaterialPalette.yellow.shadeDefault.darker;
+          return new charts.TextStyleSpec(
+            color: color,
+            fontWeight: charts.MaterialFontWeight.bold,
+          );
+        },
         // Set a label accessor to control the text of the arc label.
         labelAccessorFn: (LinearSales row, _) => '${row.year}: ${row.sales}',
       )

--- a/charts_flutter/lib/flutter.dart
+++ b/charts_flutter/lib/flutter.dart
@@ -196,3 +196,4 @@ export 'src/time_series_chart.dart';
 export 'src/user_managed_state.dart'
     show UserManagedState, UserManagedSelectionModel;
 export 'src/util/color.dart' show ColorUtil;
+export 'src/material_font_weight.dart' show MaterialFontWeight;

--- a/charts_flutter/lib/src/chart_canvas.dart
+++ b/charts_flutter/lib/src/chart_canvas.dart
@@ -26,6 +26,7 @@ import 'package:charts_common/common.dart' as common
         StyleFactory,
         TextElement,
         TextDirection;
+import 'package:charts_flutter/src/material_font_weight.dart';
 import 'package:flutter/material.dart';
 import 'text_element.dart' show TextElement;
 import 'canvas/circle_sector_painter.dart' show CircleSectorPainter;

--- a/charts_flutter/lib/src/graphics_factory.dart
+++ b/charts_flutter/lib/src/graphics_factory.dart
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 import 'package:charts_common/common.dart' as common
-    show GraphicsFactory, LineStyle, TextElement, TextStyle;
+    show GraphicsFactory, LineStyle, TextElement, TextStyle, FontWeight;
 import 'package:flutter/widgets.dart'
     show BuildContext, DefaultTextStyle, MediaQuery;
 import 'line_style.dart' show LineStyle;

--- a/charts_flutter/lib/src/material_font_weight.dart
+++ b/charts_flutter/lib/src/material_font_weight.dart
@@ -1,0 +1,81 @@
+// Copyright 2018 the Charts project authors. Please see the AUTHORS file
+// for details.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:charts_common/common.dart' as common show FontWeight;
+import 'package:flutter/material.dart' as flutter;
+import 'package:meta/meta.dart' show immutable;
+
+@immutable
+class MaterialFontWeight implements common.FontWeight {
+  final int _index;
+
+  const MaterialFontWeight._(this._index);
+
+  @override
+  int get index => _index;
+
+  // values below match material Flutter.Text.FontWeight
+  // normal and bold are exposed using abstract class,
+  // but more are available from material theme so they are exposed here
+
+  /// Thin, the least thick
+  static const MaterialFontWeight w100 = MaterialFontWeight._(0);
+
+  /// Extra-light
+  static const MaterialFontWeight w200 = MaterialFontWeight._(1);
+
+  /// Light
+  static const MaterialFontWeight w300 = MaterialFontWeight._(2);
+
+  /// Normal / regular / plain
+  static const MaterialFontWeight w400 = MaterialFontWeight._(3);
+
+  /// Medium
+  static const MaterialFontWeight w500 = MaterialFontWeight._(4);
+
+  /// Semi-bold
+  static const MaterialFontWeight w600 = MaterialFontWeight._(5);
+
+  /// Bold
+  static const MaterialFontWeight w700 = MaterialFontWeight._(6);
+
+  /// Extra-bold
+  static const MaterialFontWeight w800 = MaterialFontWeight._(7);
+
+  /// Black, the most thick
+  static const MaterialFontWeight w900 = MaterialFontWeight._(8);
+
+  /// The default font weight.
+  static const MaterialFontWeight normal = w400;
+
+  /// A commonly used font weight that is heavier than normal.
+  static const MaterialFontWeight bold = w700;
+
+  @override
+  int asFlutterFontWeightIndex() {
+    return _index;
+  }
+
+  flutter.FontWeight asFlutterFontWeight() {
+    return flutter.FontWeight.values[index];
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is MaterialFontWeight && index == other.index;
+
+  @override
+  int get hashCode => index;
+}

--- a/charts_flutter/lib/src/text_element.dart
+++ b/charts_flutter/lib/src/text_element.dart
@@ -147,7 +147,7 @@ class TextElement implements common.TextElement {
     int fontWeightIndex = 4; // normal
     if (FontWeight.values.length <
         textStyle.fontWeight.asFlutterFontWeightIndex()) {
-      fontWeightIndex = FontWeight.values.length;
+      fontWeightIndex = FontWeight.values.length - 1;
     } else if (textStyle.fontWeight.asFlutterFontWeightIndex() < 0) {
       // use default normal font weight
     } else {

--- a/charts_flutter/lib/src/text_element.dart
+++ b/charts_flutter/lib/src/text_element.dart
@@ -21,8 +21,9 @@ import 'package:charts_common/common.dart' as common
         TextDirection,
         TextMeasurement,
         TextStyle;
+import 'package:flutter/painting.dart';
 import 'package:flutter/rendering.dart'
-    show Color, TextBaseline, TextPainter, TextSpan, TextStyle;
+    show Color, TextBaseline, TextPainter, TextSpan, TextStyle, FontWeight;
 
 /// Flutter implementation for text measurement and painter.
 class TextElement implements common.TextElement {
@@ -143,12 +144,24 @@ class TextElement implements common.TextElement {
       textStyle.color.b,
     );
 
+    int fontWeightIndex = 4; // normal
+    if (FontWeight.values.length <
+        textStyle.fontWeight.asFlutterFontWeightIndex()) {
+      fontWeightIndex = FontWeight.values.length;
+    } else if (textStyle.fontWeight.asFlutterFontWeightIndex() < 0) {
+      // use default normal font weight
+    } else {
+      // use what API user set
+      fontWeightIndex = textStyle.fontWeight.asFlutterFontWeightIndex();
+    }
+
     _textPainter = new TextPainter(
         text: new TextSpan(
             text: text,
             style: new TextStyle(
                 color: color,
                 fontSize: textStyle.fontSize.toDouble(),
+                fontWeight: FontWeight.values[fontWeightIndex],
                 fontFamily: textStyle.fontFamily,
                 height: textStyle.lineHeight)))
       ..textDirection = TextDirection.ltr

--- a/charts_flutter/lib/src/text_style.dart
+++ b/charts_flutter/lib/src/text_style.dart
@@ -14,12 +14,14 @@
 // limitations under the License.
 
 import 'dart:ui' show hashValues;
-import 'package:charts_common/common.dart' as common show Color, TextStyle;
+import 'package:charts_common/common.dart' as common
+    show Color, TextStyle, FontWeight;
 
 class TextStyle implements common.TextStyle {
   int fontSize;
   String fontFamily;
   common.Color color;
+  common.FontWeight fontWeight;
   double lineHeight;
 
   @override
@@ -28,6 +30,7 @@ class TextStyle implements common.TextStyle {
       fontSize == other.fontSize &&
       fontFamily == other.fontFamily &&
       color == other.color &&
+      fontWeight == other.fontWeight &&
       lineHeight == other.lineHeight;
 
   @override


### PR DESCRIPTION
Backwards incompatible change as fontWeight used to be `String` now it's a class object 

closes #351 
![Screenshot_20200419-094835](https://user-images.githubusercontent.com/2544251/79683568-fb9b9d80-8222-11ea-9f25-67579379349b.png)


I have read contributing guidelines, `external contributions unfortunately cannot be taken at this time.` but still giving it a shot. I would rather you merge it then me fork it and release on pubdev as a fork with one fix.