### PR TITLE
fixes error thrown when using charts in page- or tabview

### DIFF
--- a/charts_flutter/lib/src/base_chart_state.dart
+++ b/charts_flutter/lib/src/base_chart_state.dart
@@ -68,7 +68,9 @@ class BaseChartState<D> extends State<BaseChart<D>>
 
   @override
   void requestRebuild() {
-    setState(() {});
+    if (mounted) {
+      setState(() {});
+    }
   }
 
   @override


### PR DESCRIPTION
As mentioned in https://github.com/google/charts/issues/277 the BaseChartState throws an error when skipping over in a page- or tabview. I've implemented the check as mentioned in the pull request and that fixes the problem. 