### PR TITLE
Pass dateTimeFactory to common.TimeSeriesChart

### DIFF
--- a/charts_flutter/lib/src/time_series_chart.dart
+++ b/charts_flutter/lib/src/time_series_chart.dart
@@ -82,7 +82,8 @@ class TimeSeriesChart extends CartesianChart<DateTime> {
         layoutConfig: layoutConfig?.commonLayoutConfig,
         primaryMeasureAxis: primaryMeasureAxis?.createAxis(),
         secondaryMeasureAxis: secondaryMeasureAxis?.createAxis(),
-        disjointMeasureAxes: createDisjointMeasureAxes());
+        disjointMeasureAxes: createDisjointMeasureAxes(),
+        dateTimeFactory: dateTimeFactory);
   }
 
   @override


### PR DESCRIPTION
Pass the user-provided dateTimeFactory to common.TimeSeriesChart.

Fix/workaround for #490 