### PR TITLE
Feature/datetime factory improvement

### DIFF
--- a/charts_common/lib/src/common/date_time_factory.dart
+++ b/charts_common/lib/src/common/date_time_factory.dart
@@ -14,19 +14,12 @@
 // limitations under the License.
 
 import 'package:intl/intl.dart' show DateFormat;
+import 'package:timezone/timezone.dart' as tz;
 
 /// Interface for factory that creates [DateTime] and [DateFormat].
 ///
 /// This allows for creating of locale specific date time and date format.
 abstract class DateTimeFactory {
-  // TODO: Per cbraun@, we need to allow setting the timezone that
-  // is used globally (along with other settings like which day the week starts
-  // on. Use DateTimeFactory - either return a local DateTime or a UTC date time
-  // based on the setting.
-
-  // TODO: We need to incorporate the time zoned calendar here
-  // because Dart DateTime doesn't do this. TZDateTime implements DateTime, so
-  // we can use DateTime as the interface.
   DateTime createDateTimeFromMilliSecondsSinceEpoch(int millisecondsSinceEpoch);
 
   DateTime createDateTime(int year,
@@ -96,3 +89,25 @@ class UTCDateTimeFactory implements DateTimeFactory {
     return DateFormat(pattern);
   }
 }
+
+/// A TimeZone aware time [DateTimeFactory].
+class TimeZoneAwareDateTimeFactory implements DateTimeFactory {
+  final tz.Location location;
+
+  const TimeZoneAwareDateTimeFactory(this.location) : assert(location != null);
+
+  DateTime createDateTimeFromMilliSecondsSinceEpoch(int millisecondsSinceEpoch) {
+    return tz.TZDateTime.fromMillisecondsSinceEpoch(location, millisecondsSinceEpoch);
+  }
+
+  DateTime createDateTime(int year,
+      [int month = 1, int day = 1, int hour = 0, int minute = 0, int second = 0, int millisecond = 0, int microsecond = 0]) {
+    return tz.TZDateTime(location, year, month, day, hour, minute, second, millisecond, microsecond);
+  }
+
+  /// Returns a [DateFormat].
+  DateFormat createDateFormat(String pattern) {
+    return new DateFormat(pattern);
+  }
+}
+

--- a/charts_common/pubspec.yaml
+++ b/charts_common/pubspec.yaml
@@ -13,6 +13,8 @@ dependencies:
   logging: any
   meta: ^1.1.1
   vector_math: ^2.0.8
+  timezone: ^0.5.7
+
 
 dev_dependencies:
   mockito: ^4.0.0

--- a/charts_flutter/lib/src/time_series_chart.dart
+++ b/charts_flutter/lib/src/time_series_chart.dart
@@ -22,7 +22,8 @@ import 'package:charts_common/common.dart' as common
         NumericAxisSpec,
         Series,
         SeriesRendererConfig,
-        TimeSeriesChart;
+        TimeSeriesChart,
+        LocalDateTimeFactory;
 import 'behaviors/chart_behavior.dart' show ChartBehavior;
 import 'behaviors/line_point_highlighter.dart' show LinePointHighlighter;
 import 'cartesian_chart.dart' show CartesianChart;
@@ -82,7 +83,8 @@ class TimeSeriesChart extends CartesianChart<DateTime> {
         layoutConfig: layoutConfig?.commonLayoutConfig,
         primaryMeasureAxis: primaryMeasureAxis?.createAxis(),
         secondaryMeasureAxis: secondaryMeasureAxis?.createAxis(),
-        disjointMeasureAxes: createDisjointMeasureAxes());
+        disjointMeasureAxes: createDisjointMeasureAxes(),
+        dateTimeFactory: dateTimeFactory ?? const common.LocalDateTimeFactory());
   }
 
   @override


### PR DESCRIPTION
No breaking changes
-**Added the missing dateTimeFactory parameter** on TimeSeriesChart.createCommonChart method.
It also fixes #490 

-**Added a Timezone aware DateTimeFactory implementation** (related to a TODO left for @cbbraun)
I use this implementation in a prod application with localized Data visualisation, this feature is needed and useful. 

@lorrainekan , as you seem to be the most active maintainer on this repo on this repo, could you please take a look ? :) Thanks a lot 🙏

Corentin