### PR TITLE
Show BarErrorDecorator in export

### DIFF
--- a/charts_flutter/lib/flutter.dart
+++ b/charts_flutter/lib/flutter.dart
@@ -34,6 +34,7 @@ export 'package:charts_common/common.dart'
         Axis,
         AxisDirection,
         AxisSpec,
+        BarErrorDecorator,
         BarGroupingType,
         BarLabelAnchor,
         BarLabelDecorator,


### PR DESCRIPTION
The working `BarErrorDecorator` was not shown in the export.

I tested it manually and it seems to work quite well.
Further, there are no tests for other exported decorators, so i did not write any for this decorator.