### PR TITLE
Loosen intl constraint

### DIFF
--- a/charts_common/CHANGELOG.md
+++ b/charts_common/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.9.1
+* Loosened `intl` constraint to allow running on Flutter `beta` and later, which requires the NNBD
+  version of `intl`.
+
 # 0.9.0
 * Internal bug fixes
 * Bump versions in Gemlock file due to security alerts

--- a/charts_common/pubspec.yaml
+++ b/charts_common/pubspec.yaml
@@ -1,5 +1,5 @@
 name: charts_common
-version: 0.9.0
+version: 0.9.1
 description: A common library for charting packages.
 author: Charts Team <charts_flutter@google.com>
 homepage: https://github.com/google/charts
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   collection: ^1.14.5
-  intl: '>=0.15.2 < 0.17.0'
+  intl: '>=0.15.2 < 0.18.0'
   logging: any
   meta: ^1.1.1
   vector_math: ^2.0.8

--- a/charts_flutter/CHANGELOG.md
+++ b/charts_flutter/CHANGELOG.md
@@ -1,4 +1,8 @@
 # 0.9.0
+* Loosened `intl` constraint to allow running on Flutter `beta` and later, which requires the NNBD
+  version of `intl`.
+
+# 0.9.0
 * Internal bug fixes
 * Bump versions in Gemlock file due to security alerts
 

--- a/charts_flutter/CHANGELOG.md
+++ b/charts_flutter/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.9.0
+# 0.9.1
 * Loosened `intl` constraint to allow running on Flutter `beta` and later, which requires the NNBD
   version of `intl`.
 

--- a/charts_flutter/pubspec.yaml
+++ b/charts_flutter/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   collection: ^1.14.5
   flutter:
     sdk: flutter
-  intl: '>=0.15.2 < 0.17.0'
+  intl: '>=0.15.2 < 0.18.0'
   logging: any
   meta: ^1.1.1
 

--- a/charts_flutter/pubspec.yaml
+++ b/charts_flutter/pubspec.yaml
@@ -1,5 +1,5 @@
 name: charts_flutter
-version: 0.9.0
+version: 0.9.1
 description: Material Design charting library for flutter.
 author: Charts Team <charts_flutter@google.com>
 homepage: https://github.com/google/charts

--- a/charts_flutter/pubspec.yaml
+++ b/charts_flutter/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   #
   # The pub version of charts_flutter will point to the pub version of charts_common.
   # The latest pub version is commented out and shown below as an example.
-  # charts_common: 0.9.0
+  # charts_common: 0.9.1
   charts_common:
     path: ../charts_common/
   collection: ^1.14.5


### PR DESCRIPTION
Fixes the bug described in #579.

`charts_flutter` can currently not be used on `beta` and later without a dependency override because the Flutter framework depends on the null-safe version of `charts_flutter`.

Previously, you would need to add the following override to your app's Pubspec:

```yaml
dependency_overrides:
  intl: ^0.17.0-nullsafety.2
```