### PR TITLE
Update to allow intl in pubspec.yaml to be imported <= version 0.17.0…

### DIFF
--- a/charts_common/pubspec.yaml
+++ b/charts_common/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   collection: ^1.14.5
-  intl: '>=0.15.2 < 0.17.0'
+  intl: '>=0.15.2 <= 0.17.0'
   logging: any
   meta: ^1.1.1
   vector_math: ^2.0.8

--- a/charts_flutter/pubspec.yaml
+++ b/charts_flutter/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   collection: ^1.14.5
   flutter:
     sdk: flutter
-  intl: '>=0.15.2 < 0.17.0'
+  intl: '>=0.15.2 <= 0.17.0'
   logging: any
   meta: ^1.1.1
 


### PR DESCRIPTION
This is to enable compatibility within any apps requiring both `firebase_auth^1.0.0` and `charts_flutter` when packaging the two components in the same app.

For example, when building a project which depends on the latest `charts_flutter^0.9.0` *and* `firebase_auth^1.0.0`:

```
PS C:\Users\SomeUser\Development\someApp> flutter pub get
Because no versions of charts_flutter match >0.9.0 <0.10.0 and charts_flutter 0.9.0 depends on intl >=0.15.2 <0.17.0, charts_flutter ^0.9.0 requires intl >=0.15.2 <0.17.0.
And because firebase_auth >=1.0.0 depends on firebase_auth_web ^1.0.0 which depends on intl ^0.17.0, charts_flutter ^0.9.0 is incompatible with firebase_auth >=1.0.0.
So, because someApp depends on both firebase_auth ^1.0.0 and charts_flutter ^0.9.0, version solving failed.
Running "flutter pub get" in someApp...
pub get failed (1; So, because someApp depends on both firebase_auth ^1.0.0 and charts_flutter ^0.9.0, version solving failed.)
```

It's just a single comparator in the version designation (`<=` vs `<`), and the tests continute to pass, so I hope this is just a small omission/typo in version pinning between two (Google) libraries.

Closes #602