### PR TITLE
Error: The getter 'body1' isn't defined for the class 'TextTheme'.

### DIFF
--- a/charts_flutter/lib/src/behaviors/legend/legend_entry_layout.dart
+++ b/charts_flutter/lib/src/behaviors/legend/legend_entry_layout.dart
@@ -131,7 +131,7 @@ class SimpleLegendEntryLayout implements LegendEntryLayout {
         : null;
     if (isHidden) {
       // Use a default color for hidden legend entries if none is provided.
-      color ??= Theme.of(context).textTheme.bodyText2!.color;
+      color ??= Theme.of(context).textTheme.body1!.color;
       color = color!.withOpacity(0.26);
     }
 


### PR DESCRIPTION
Bug thrown by the Flutter Debug Console:
'TextTheme' is from 'package:flutter/src/material/text_theme.dart' ('../../../snap/flutter/common/flutter/packages/flutter/lib/src/material/text_theme.dart').
Try correcting the name to the name of an existing getter, or defining a getter or field named 'body1'.
      color ??= Theme.of(context).textTheme.body1!.color;