### PR TITLE
update sdk version example pubspec.yaml

### DIFF
--- a/charts_flutter/example/pubspec.yaml
+++ b/charts_flutter/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: example
 description: Charts-Flutter Demo
 environment:
-  sdk: '>=1.23.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dependencies:
   charts_flutter:
     path: ../


### PR DESCRIPTION
The flutter example does not work with compile errors ( null check, etc...).
The reason is that the sdk version in pubspec.yaml is old.
Therefore, I fixed sdk version in pubspec.yaml to 2.12.0.