### PR TITLE
Update chart_container.dart

### DIFF
--- a/charts_flutter/lib/src/chart_container.dart
+++ b/charts_flutter/lib/src/chart_container.dart
@@ -202,11 +202,11 @@ class ChartContainerRenderObject<D> extends RenderCustomPaint
 
     // Sometimes chart behaviors try to draw the chart outside of a Flutter draw
     // cycle. Schedule a frame manually to handle these cases.
-    if (!SchedulerBinding.instance!.hasScheduledFrame) {
-      SchedulerBinding.instance!.scheduleFrame();
+    if (!SchedulerBinding.instance.hasScheduledFrame) {
+      SchedulerBinding.instance.scheduleFrame();
     }
 
-    SchedulerBinding.instance!.addPostFrameCallback(startAnimationController);
+    SchedulerBinding.instance.addPostFrameCallback(startAnimationController);
   }
 
   /// Request Flutter to rebuild the widget/container of chart.
@@ -229,7 +229,7 @@ class ChartContainerRenderObject<D> extends RenderCustomPaint
     // This is needed to request rebuild after the legend has been added in the
     // post process phase of the chart, which happens during the chart widget's
     // build cycle.
-    SchedulerBinding.instance!.addPostFrameCallback(doRebuild);
+    SchedulerBinding.instance.addPostFrameCallback(doRebuild);
   }
 
   /// When Flutter's markNeedsLayout is called, layout and paint are both


### PR DESCRIPTION
Removed unnecessary null-aware operators on lines 205, 206, 209, 232.

This fixes chart_container.dart:205:27: Warning: Operand of null-aware operation '!' has type 'SchedulerBinding' which excludes null Error which does appear on latest flutter version!

Fixes this issue https://github.com/google/charts/issues/735.