### PR TITLE
Update donut.md

### DIFF
--- a/docs/flutter/example/pie_charts/donut.md
+++ b/docs/flutter/example/pie_charts/donut.md
@@ -31,7 +31,7 @@ class DonutPieChart extends StatelessWidget {
         animate: animate,
         // Configure the width of the pie slices to 60px. The remaining space in
         // the chart will be left as a hole in the center.
-        defaultRenderer: new charts.ArcRendererConfig(arcWidth: 60));
+        defaultRenderer: charts.ArcRendererConfig<Object>(arcWidth: 60));
   }
 
   /// Create one series with sample hard coded data.


### PR DESCRIPTION
new Keyword is unnecessary and ArcRendererConfig must be of type object, otherwise error is thrown because dynamic is not a subtype of object