### PR TITLE
fix: set `ArcRendererElement<D>` to `ArcRendererElement<Object>`

### DIFF
--- a/docs/flutter/example/pie_charts/outside_label.md
+++ b/docs/flutter/example/pie_charts/outside_label.md
@@ -39,7 +39,7 @@ class PieOutsideLabelChart extends StatelessWidget {
         //       new charts.ArcLabelDecorator(
         //          insideLabelStyleSpec: new charts.TextStyleSpec(...),
         //          outsideLabelStyleSpec: new charts.TextStyleSpec(...)),
-        defaultRenderer: new charts.ArcRendererConfig(arcRendererDecorators: [
+        defaultRenderer: new charts.ArcRendererConfig<Object>(arcRendererDecorators: [
           new charts.ArcLabelDecorator(
               labelPosition: charts.ArcLabelPosition.outside)
         ]));


### PR DESCRIPTION
Fix error `_CastError (type 'List<ArcRendererElement<dynamic>>' is not a subtype of type 'List<ArcRendererElement<Object>>?' in type cast)`