### PR TITLE
fix: destroy chart on dispose

### DIFF
--- a/charts_flutter/lib/src/chart_container.dart
+++ b/charts_flutter/lib/src/chart_container.dart
@@ -300,6 +300,12 @@ class ChartContainerRenderObject<D> extends RenderCustomPaint
         a11yNodes: _a11yNodes ?? [],
         textDirection: textDirection);
   }
+
+  @override
+  void dispose() {
+    _chart!.destroy();
+    super.dispose();
+  }
 }
 
 class ChartContainerCustomPaint extends CustomPainter {


### PR DESCRIPTION
Fixes: #779 

Right now charts are not disposing its resources when the widget is removed from the widget tree permanently.